### PR TITLE
Add a GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,18 @@
+name: lint_python
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+      - run: pip install black codespell flake8 isort pytest
+      - run: black . --diff || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --recursive . || true
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true

--- a/apps/Products/models.py
+++ b/apps/Products/models.py
@@ -80,7 +80,7 @@ class Command(models.Model):
 
         Returns the number of arguments associated to "self"
         """
-        return count(self.get_arguments())
+        return len(self.get_arguments())
 
     def arguments(self):
         args = []

--- a/apps/Servers/views.py
+++ b/apps/Servers/views.py
@@ -338,7 +338,7 @@ def run_script(filename, params, client, type_script):
     _data = dict()
     try:
         exec_command = "../TestScripts/{0}_test_case.robot".format(filename)
-        if type_script is 3:
+        if type_script == 3:
             exec_command = "../TestSuites/{0}_test_suite.robot".format(filename)
         config = params.get('config')
         arguments = params.get('global_variables')
@@ -467,7 +467,7 @@ def generate_file(obj, type_script, params, filename, client):
             name__in=['Dialogs', 'Screenshot']
         ).values_list('name', flat=True)
         """Generate robot files"""
-        if type_script is 1:
+        if type_script == 1:
             extra_elements = json.loads(obj.extra_imports)
             resources = generate_resource_files(extra_elements)
 
@@ -515,7 +515,7 @@ def generate_file(obj, type_script, params, filename, client):
 
             send_files(dummy_tc_file.name, 5, config, client)
 
-        elif type_script is 2:
+        elif type_script == 2:
             items = search_for_script_names(obj.script)
             if items.get('error'):
                 raise Exception(items.get('error'))
@@ -549,7 +549,7 @@ def generate_file(obj, type_script, params, filename, client):
             if check.get('text'):
                 raise Exception(check.get('text'))
 
-        elif type_script is 3:
+        elif type_script == 3:
             """Test Suite """
             items = search_for_script_names(obj.script)
             if items.get('error'):
@@ -587,7 +587,7 @@ def generate_file(obj, type_script, params, filename, client):
             if check.get('text'):
                 raise Exception(check.get('text'))
 
-        elif type_script is 4:
+        elif type_script == 4:
             """ Imported Keywords """
             """ Dummy Test Case file"""
             dummy_tc_file = open("{0}/test_keywords/{1}_test_case.robot".format(settings.MEDIA_ROOT, filename),
@@ -654,21 +654,21 @@ def run_on_server(_data):
         configs = params.get('config')
         filename = _data.get('filename')
         client = get_connection(configs)
-        if type_script is 1:
+        if type_script == 1:
             """is keywords"""
             obj = Keyword.objects.get(id=_data.get('obj_id'))
-            if obj.script_type is 2:
+            if obj.script_type == 2:
                 type_script = 4
-        elif type_script is 2:
+        elif type_script == 2:
             """is Test Case"""
             obj = TestCase.objects.get(id=_data.get('obj_id'))
-        elif type_script is 3:
+        elif type_script == 3:
             """is Test Case"""
             obj = TestSuite.objects.get(id=_data.get('obj_id'))
         _data = generate_file(obj, type_script, params, filename, client)
         if _data.get('error'):
             raise Exception(_data['error'])
-        if profile_category is 2:
+        if profile_category == 2:
             """Run pybot only if the user choose -> Local Network connection"""
             result = run_script(filename, params, client, type_script)
             if result.get('error'):

--- a/apps/Testings/views.py
+++ b/apps/Testings/views.py
@@ -314,11 +314,11 @@ class RunScriptView(LoginRequiredMixin, HasPermissionsMixin, TemplateView):
         type_script = int(kwargs.get('type_script'))
         scripts = ['Keyword', 'Test Case', 'Test Suite']
         if type_script:
-            if type_script is 1:
+            if type_script == 1:
                 obj = Keyword.objects.get(pk=kwargs.get('pk'))
-            if type_script is 2:
+            if type_script == 2:
                 obj = TestCase.objects.get(pk=kwargs.get('pk'))
-            if type_script is 3:
+            if type_script == 3:
                 obj = TestSuite.objects.get(pk=kwargs.get('pk'))
             context['obj'] = obj
             context['type'] = scripts[type_script - 1]

--- a/apps/Users/models.py
+++ b/apps/Users/models.py
@@ -82,10 +82,10 @@ class User(AbstractBaseUser, PermissionsMixin):
         for task in self.tasks.all().order_by('-created_at')[:6]:
             res = AsyncResult(task.task_id)
             if res.ready() and res.state != task.state:
-                if task.category is 1:
+                if task.category == 1:
                     task.state = res.state
                     task.task_info = res.result or ''
-                if task.category is 2:
+                if task.category == 2:
                     try:
                         if res.result.get('error'):
                             task.state = 'FAILURE'
@@ -99,7 +99,7 @@ class User(AbstractBaseUser, PermissionsMixin):
                         task.task_info = "Celery or Message broker stopped"
                 task.save()
             
-            if task.category is 1:
+            if task.category == 1:
                 try:
                     task.task_info = json.loads(task.task_info)
                 except ValueError:

--- a/apps/apis/views.py
+++ b/apps/apis/views.py
@@ -600,13 +600,13 @@ class RunOnServerApiView(LoginRequiredMixin, APIView):
             _data['obj_id'] = obj_id
             _data['type_script'] = type_script
             _data['profiles'] = json.loads(request.data.get('profile'))
-            if type_script is 1:
+            if type_script == 1:
                 """is keywords"""
                 obj = Keyword.objects.get(id=obj_id)
-            elif type_script is 2:
+            elif type_script == 2:
                 """is Test Case"""
                 obj = TestCase.objects.get(id=obj_id)
-            elif type_script is 3:
+            elif type_script == 3:
                 """is Test Suite"""
                 obj = TestSuite.objects.get(id=obj_id)
             if obj:

--- a/extracts.py
+++ b/extracts.py
@@ -381,7 +381,7 @@ class MExtract:
 
         Returns source object
         """
-        if category is 2:
+        if category == 2:
             if self.api_config.get('host'):
                 name = "{0} - {1}".format(distro.linux_distribution()[0], distro.linux_distribution()[1])
                 version = self.api_config.get('host')
@@ -399,7 +399,7 @@ class MExtract:
             except Exception as error:
                 source = "None"
                 print(" error in get OS: {}".format(error))
-        elif category is 3:
+        elif category == 3:
             try:
                 source = Source.objects.get(id=self.api_config.get("source"))
             except Exception as error:
@@ -517,7 +517,7 @@ class RExtract():
         self.extra_libraries = list()
         self.source_dict = dict()
         _category = int(config.get('category'))
-        if _category is 4:
+        if _category == 4:
             self.zip = zipfile.ZipFile(config.get("zip"))
             for path in self.zip.namelist():
                 if re.search(r'/libraries/', path):
@@ -535,7 +535,7 @@ class RExtract():
                     instance.depends.add(self.r_version)
                     instance.save()
                     self.source_dict[name] = instance
-        elif _category is 5:
+        elif _category == 5:
             self.lib_url = config.get("url")
             req = urllib.request.Request(self.lib_url)
             res = urllib.request.urlopen(req)

--- a/extracts.py
+++ b/extracts.py
@@ -32,12 +32,12 @@ def run_extract(config):
         3 or 4  -    R-Extract
     """
     category = int(config.get('category'))
-    if category is 2:
+    if category == 2:
         # Extract Manpages
         m = MExtract(api_config=config)
         m.run()
 
-    elif category is 3:
+    elif category == 3:
         # Extract Product Commands
         p = PExtract(config)
         p.run()


### PR DESCRIPTION
Add a GitHub Action to find Python syntax errors and undefined names.
https://github.com/cclauss/BlueXolo/actions  # These tests find and this PR fixes 26 issues.
```
25    F632 use ==/!= to compare str, bytes, and int literals
1     F821 undefined name 'count'
26
```

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.