### PR TITLE
Adjust position of button to add commands

### DIFF
--- a/apps/Products/templates/commands.html
+++ b/apps/Products/templates/commands.html
@@ -78,17 +78,17 @@
             </div>
         </div>
         <div class="fixed-action-btn">
-            <a id="menu" class="btn-floating btn-large blue-grey">
+            <a id="menu" style="float:left;margin:0.7rem;right:260px;bottom:5px;" class="btn-floating btn-large blue-grey">
                 <i class="large material-icons">add</i>
             </a>
             <ul>
                 {% if stepper != 'stepper' %}
-                <li><a class="btn-floating blue tooltipped" data-position="left" data-delay="50"
+                <li><a style="float:left;margin:0.7rem;right:255px;bottom:5px;" class="btn-floating blue tooltipped" data-position="left" data-delay="50"
                        data-tooltip="Manual" href="{% url "new-command" %}">
                     <i class="material-icons">create</i></a></li>
                 {% endif %}
                 <li>
-                    <button class="btn-floating green tooltipped" data-position="left" data-delay="50"
+                    <button style="float:left;margin:0.7rem;right:255px;bottom:10px;" class="btn-floating green tooltipped" data-position="left" data-delay="50"
                             data-tooltip="Extract from Operation System (M-Extract)" onclick="modal_extract()">
                         <i class="material-icons">launch</i>
                     </button>


### PR DESCRIPTION
## List of changes:
* Move the add button to make it more visible.
* Also move the other two floating button according to the add button.
> This pull request is related to the story #198, that story was closed but a change in the commands page was missing, this code modification is based on the format of the original fix of #198.