### PR TITLE
#432 duplicated test cases in test suite

### DIFF
--- a/static/js/dragNDrop/jsonManipulator.js
+++ b/static/js/dragNDrop/jsonManipulator.js
@@ -58,6 +58,7 @@ function addTestcaseToJSON(indentation, testcaseID) {
             var valuesAsString = data.values;
             var testcaseValues = JSON.parse(valuesAsString.replace(/&quot;/g, '"'));
             var testcaseCategory = 7;
+            var testcaseScript = data.script || "";
 
             droppedElements.push({
                 id: testcaseID,
@@ -68,6 +69,7 @@ function addTestcaseToJSON(indentation, testcaseID) {
                 indentation: indentation,
                 keywordJSON: testcaseValues,
                 arguments: testcaseArguments,
+                script: testcaseScript,
                 extraValue: undefined,
             });
             drawElementsFromJSON();
@@ -94,6 +96,7 @@ function addTestcaseToJSONInIndex(indentation, testcaseID, addElementInThisPosit
             var valuesAsString = data.values;
             var testcaseValues = JSON.parse(valuesAsString.replace(/&quot;/g, '"'));
             var testcaseCategory = 7;
+            var testcaseScript = data.script || "";
 
             var droppedElement = {
                 id: testcaseID,
@@ -104,6 +107,7 @@ function addTestcaseToJSONInIndex(indentation, testcaseID, addElementInThisPosit
                 indentation: indentation,
                 keywordJSON: testcaseValues,
                 arguments: testcaseArguments,
+                script: testcaseScript,
                 extraValue: undefined,
             };
             droppedElements.splice(addElementInThisPosition, 0, droppedElement);

--- a/static/js/dragNDrop/translatorToRobot.js
+++ b/static/js/dragNDrop/translatorToRobot.js
@@ -356,7 +356,10 @@ function translateToRobot(callBackFunction) {
         }
 
         if (droppedElements[i].category === testcaseDroppedCategory) {
-
+            if (terminal.value === "") {
+                terminal.value = "*** Test Cases ***\n";
+            }
+            
             if(!addedOwnDescription){
                 addOwnDescription();
 
@@ -372,12 +375,24 @@ function translateToRobot(callBackFunction) {
 
             var testcaseUsedID = droppedElements[i].id;
             var newTestcaseUsed = droppedElements[i];
-
+            
             if (newTestcaseUsed.keywordJSON[0].script_type !== 'Imported Script') {
                 var testCaseTranslation = addTestcaseToUsedArray(testcaseUsedID, newTestcaseUsed);
                 if (isTestsuite()) {
                     terminal.value += testCaseTranslation;
                 }
+            }
+            else {
+                var importedScript = droppedElements[i].script;
+
+                if (importedScript !== "") {
+                    const testcaseHeaderLength = "\n*** Test Cases ***\n".length;  
+
+                    // This removes the "*** Test Cases ***" part of the imported test case script
+                    importedScript = importedScript.substr(testcaseHeaderLength, importedScript.length);
+                }
+                
+                terminal.value += importedScript;
             }
 
             if ((i + 1) >= droppedElements.length) {
@@ -656,8 +671,8 @@ function addExtraToUsedArray(sourceID){
     usedExtras.push(newElement);
 }
 
-function addTestcaseToUsedArray( testcaseID, testcase){
-    var translation = "*** Test Cases ***\n";
+function addTestcaseToUsedArray(testcaseID, testcase){
+    var translation = "";
     translation += testcase.name + "\n";
     translation += "    [Documentation]    ";
     translation += testcase.description + "\n";

--- a/static/js/dragNDrop/translatorToRobot.js
+++ b/static/js/dragNDrop/translatorToRobot.js
@@ -365,7 +365,10 @@ function translateToRobot(callBackFunction) {
 
             var testcaseName = droppedElements[i].name;
             var translatedRow = handleTestcaseSection(testcaseName);
-            terminal.value += translatedRow;
+
+            if (!isTestsuite()) {
+                terminal.value += translatedRow;
+            }
 
             var testcaseUsedID = droppedElements[i].id;
             var newTestcaseUsed = droppedElements[i];


### PR DESCRIPTION
**Description:**
* Add script data in the dropped elements for translation process (just for Test Cases).
* Prevent to add multiple times the test cases header "_*** Test Cases ***_" during the Test Suite script translation.
* Avoid duplication of native Test Case names in the text script.