### PR TITLE
fixed Google group's link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you experience any issues with BlueXolo on any Operating System, or you have 
 
 ## Contact Links
 
-[BlueXolo Google Group (edited)](https://groups.google.com/forum/#!forum/bluexolo)
+[BlueXolo Google Group (edited)](https://groups.google.com/forum/#!forum/bluexolo/join)
 [BlueXolo Web Page](https://ibm.github.io/BlueXolo/)
 [BlueXolo ZenHub](https://app.zenhub.com/workspaces/bluexolo-5c09910d4b5806bc2bfb46c4/board)
 [BlueXolo GitHub](https://github.com/IBM/BlueXolo)

--- a/templates/footer-block.html
+++ b/templates/footer-block.html
@@ -19,7 +19,7 @@
             </div>
             <div class="col l2" style="padding-top: 40px;">
                 <ul>
-                    <li><a class="grey-text text-lighten-3" target="blank" href="https://groups.google.com/forum/#!forum/bluexolo">Google Group</a></li>
+                    <li><a class="grey-text text-lighten-3" target="blank" href="https://groups.google.com/forum/#!forum/bluexolo/join">Google Group</a></li>
                     <li><a class="grey-text text-lighten-3" target="blank" href="https://github.com/IBM/BlueXolo">GitHub Repository</a></li>
                     <li><a class="grey-text text-lighten-3" target="blank" href="https://www.youtube.com/channel/UCnCOvCcx3VH88wGxeYJ-qQQ">YouTube Channel</a></li>
                 </ul>


### PR DESCRIPTION
Fixed the link to add "/join" at the end to allow users that aren't part of the group to be able to see or join it.