### PR TITLE
Reverse proxy to handle botpress requests

### DIFF
--- a/CTAFramework/context_processors.py
+++ b/CTAFramework/context_processors.py
@@ -5,3 +5,8 @@ def sitewide(request):
     'PLATFORM_VERSION': settings.PLATFORM_VERSION,
     'CONTENT_ONLY': request.GET.get('content_only', False)
   }
+
+def botpress_endpoint(request):
+  return {
+    'BOTPRESS_ENDPOINT': settings.BOTPRESS_ENDPOINT
+  }

--- a/CTAFramework/settings.py
+++ b/CTAFramework/settings.py
@@ -98,7 +98,8 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-                "CTAFramework.context_processors.sitewide"
+                "CTAFramework.context_processors.sitewide",
+                "CTAFramework.context_processors.botpress_endpoint"
             ],
         },
     },
@@ -169,6 +170,8 @@ COMPRESS_ROOT = STATIC_ROOT
 
 MEDIA_ROOT = "/var/www/media"
 MEDIA_URL = "media/"
+
+BOTPRESS_ENDPOINT = os.environ.get("BOTPRESS_ENDPOINT")
 
 AUTH_USER_MODEL = "Users.User"
 

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -4,7 +4,6 @@ services:
     image: bluexolo/bluexolo:production
     volumes:
       - media:/var/www/media
-      - static:/var/www/static
     env_file:
       - ./.env
     build:
@@ -22,21 +21,25 @@ services:
     restart: on-failure
   proxy:
     image: bluexolo/proxy:nginx
+    restart: always
     build:
-      context: ./proxy
-      dockerfile: proxy.dockerfile
+      context: .
+      dockerfile: ./proxy/proxy.dockerfile
     volumes:
-      - static:/var/www/static
       - media:/var/www/media
     environment:
       NGINX_PORT: 80
       BLUEXOLO_HOST: bluexolo
       BLUEXOLO_PORT: 8000
+      BOTPRESS_HOST: bluexolo-assistant
+      BOTPRESS_PORT: 3000
+      NGINX_ENTRYPOINT_QUIET_LOGS: 1
     ports:
       - "80:80"
     container_name: bluexolo-proxy
     depends_on:
       - bluexolo
+      - botpress
     restart: on-failure
   redis:
     image: redis:6.2.1-alpine
@@ -60,9 +63,14 @@ services:
     command: -c listen_addresses=*
   botpress:
     image: bluexolo/assistant
-    ports:
-      - "3000:3000"
     container_name: bluexolo-assistant
+    environment: 
+      EXTERNAL_URL: "http://localhost/botpress"
+      BP_HOST: "localhost"
+      PORT: 3000
+      REVERSE_PROXY: 1
+      BP_PRODUCTION: 1
+      VERBOSITY_LEVEL: 1
   robot3.2.2:
     image: bluexolo/robot:3.2.2
     volumes:
@@ -97,4 +105,3 @@ services:
 volumes:
   media:
   db:
-  static:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,6 +46,9 @@ services:
     ports:
       - "3000:3000"
     container_name: bluexolo-assistant
+    environment:
+      BP_PRODUCTION: 0
+      VERBOSITY_LEVEL: 3
   robot3.2.2:
     image: bluexolo/robot:3.2.2
     volumes:

--- a/proxy/default.conf.template
+++ b/proxy/default.conf.template
@@ -1,6 +1,27 @@
 server {
     listen ${NGINX_PORT};
 
+    location ~ .*/assets/.* {
+      proxy_pass http://${BOTPRESS_HOST}:${BOTPRESS_PORT};
+      proxy_ignore_headers Cache-Control;
+      proxy_hide_header Cache-Control;
+      proxy_hide_header Pragma;
+      proxy_cache_valid any 30m;
+      proxy_set_header Cache-Control max-age=30;
+      add_header Cache-Control max-age=30;
+    }
+    
+    location ~ .*/socket.io/.* {
+      proxy_pass http://${BOTPRESS_HOST}:${BOTPRESS_PORT};
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+    }
+    
+    location /botpress {
+      proxy_pass http://${BOTPRESS_HOST}:${BOTPRESS_PORT}/botpress;
+    }
+    
     location /static {
         alias /var/www/static;
     }
@@ -13,6 +34,6 @@ server {
         uwsgi_pass ${BLUEXOLO_HOST}:${BLUEXOLO_PORT};
         include /etc/nginx/uwsgi_params;
     }
-    
+
     client_max_body_size 0;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -65,9 +65,9 @@
 </script>
 
 <!-- Chatbot -->
-<script src="http://localhost:3000/assets/modules/channel-web/inject.js"></script>
+<script src="{{ BOTPRESS_ENDPOINT }}/assets/modules/channel-web/inject.js"></script>
 <script>
-    window.botpressWebChat.init({ host: 'http://localhost:3000', botId: 'bluexolo-assistant', id: 'bluexolo-assistant' })
+    window.botpressWebChat.init({ host: '{{ BOTPRESS_ENDPOINT }}', botId: 'bluexolo-assistant', id: 'bluexolo-assistant' });
 </script>
 <script>
     var chatbotButton = document.getElementById("bp-widget");

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -56,9 +56,9 @@
     </main>
 
     <!-- Chatbot -->
-    <script src="http://localhost:3000/assets/modules/channel-web/inject.js"></script>
+    <script src="{{ BOTPRESS_ENDPOINT }}/assets/modules/channel-web/inject.js"></script>
     <script>
-        window.botpressWebChat.init({ host: 'http://localhost:3000', botId: 'bluexolo-assistant' })
+        window.botpressWebChat.init({ host: '{{ BOTPRESS_ENDPOINT }}', botId: 'bluexolo-assistant' })
     </script>
 
     <!-- Footer -->


### PR DESCRIPTION
Consume botpress service from an endpoint defined in `settings.py`, a reverse proxy was implemented for production scenarios to avoid exposing to public traffic the botpress container/pod.

Closes #520 