### PR TITLE
#524 error in request to apis

### DIFF
--- a/proxy/default.conf.template
+++ b/proxy/default.conf.template
@@ -21,6 +21,10 @@ server {
     location /botpress {
       proxy_pass http://${BOTPRESS_HOST}:${BOTPRESS_PORT}/botpress;
     }
+
+    location /api/ {
+        proxy_pass http://assistant.bluexolo:3000/botpress/api/;
+    }
     
     location /static {
         alias /var/www/static;

--- a/proxy/default.conf.template
+++ b/proxy/default.conf.template
@@ -23,7 +23,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://assistant.bluexolo:3000/botpress/api/;
+        proxy_pass http://${BOTPRESS_HOST}:${BOTPRESS_PORT}/botpress/api/;
     }
     
     location /static {


### PR DESCRIPTION
Traffic to /apis was being redirected to assistant container instead of BlueXolo container.

Fixes #524 