### PR TITLE
Update TLS certificates and Documentation

### DIFF
--- a/OPS/K8/GKE/README.md
+++ b/OPS/K8/GKE/README.md
@@ -62,3 +62,5 @@ The IP to be selected is the one in the "EXTERNAL-IP" column. To access the site
 ```
 
 To destroy the cluster simply run the ***kill-cluster.bat*** script.
+
+To configure HTTPS please visit this [page](https://github.com/IBM/BlueXolo/issues/518). 


### PR DESCRIPTION
- The TLS certificates have been updated and will be valid until Jan 2022.
- The cluster documentation file was updated to have the process to deploy the certificates inside the ngnix pod made by @snvc00.  